### PR TITLE
Added support for Boost 1.70

### DIFF
--- a/discordpp/websocket-beast.hh
+++ b/discordpp/websocket-beast.hh
@@ -33,7 +33,13 @@ namespace discordpp {
             json jres;
             {
                 std::ostringstream ss;
+
+#if BOOST_VERSION >= 107000
+                ss << boost::beast::make_printable(buffer_.data());
+#else
                 ss << boost::beast::buffers(buffer_.data());
+#endif
+				
                 buffer_.consume(buffer_.size());
                 //std::cerr << "Got " << ss.str() << '\n';
                 jres = json::parse(ss.str());


### PR DESCRIPTION
Boost 1.70 deprecates boost::beast::buffer, this commit should fix the issue.